### PR TITLE
Adds percent encodable check before deciding if doing double call or one

### DIFF
--- a/SDK/Sources/Models/Record/TagGroup.swift
+++ b/SDK/Sources/Models/Record/TagGroup.swift
@@ -50,6 +50,12 @@ struct TagGroup: Equatable {
         return tags.formattedKeyValuePairs(separatedBy: separator, usingPercentEncoding: percentEncoding) + formattedAnnotations
     }
 
+    func hasPercentEncodableCharacters() throws -> Bool {
+        let percentEncodedParameters = try asParameters(percentEncoding: true)
+        let nonPercentEncodedParameters = try asParameters(percentEncoding: false)
+        return percentEncodedParameters != nonPercentEncodedParameters
+    }
+
     private func validateAnnotations() throws {
         for annotation in annotations {
             guard !annotation.isEmpty else {

--- a/SDK/Sources/Models/Record/TagGroup.swift
+++ b/SDK/Sources/Models/Record/TagGroup.swift
@@ -51,8 +51,8 @@ struct TagGroup: Equatable {
     }
 
     func hasPercentEncodableCharacters() throws -> Bool {
-        let percentEncodedParameters = try asParameters(percentEncoding: true)
-        let nonPercentEncodedParameters = try asParameters(percentEncoding: false)
+        let percentEncodedParameters = try asParameters(percentEncoding: true).sorted()
+        let nonPercentEncodedParameters = try asParameters(percentEncoding: false).sorted()
         return percentEncodedParameters != nonPercentEncodedParameters
     }
 

--- a/SDK/Sources/Services/RecordService.swift
+++ b/SDK/Sources/Services/RecordService.swift
@@ -141,6 +141,26 @@ struct RecordService: RecordServiceType {
                                             offset: Int?,
                                             annotations: [String] = [],
                                             decryptedRecordType: DR.Type = DR.self) -> Async<[DR]> {
+        searchRecordsIncludingLegacyTaggedOnes(for: userId, from: startDate, to: endDate, pageSize: pageSize, offset: offset, annotations: annotations, decryptedRecordType: decryptedRecordType)
+
+    }
+
+    func countRecords<R: SDKResource>(userId: String, resourceType: R.Type, annotations: [String] = []) -> Async<Int> {
+        countRecordsIncludingLegacyTaggedOnes(userId: userId, resourceType: resourceType, annotations: annotations)
+    }
+}
+
+// MARK: - Legacy Record Handling
+extension RecordService {
+
+    /// See jira issue for more info: [SDK-521](https://gesundheitscloud.atlassian.net/browse/SDK-521)
+    private func searchRecordsIncludingLegacyTaggedOnes<DR: DecryptedRecord>(for userId: String,
+                                                                             from startDate: Date?,
+                                                                             to endDate: Date?,
+                                                                             pageSize: Int?,
+                                                                             offset: Int?,
+                                                                             annotations: [String] = [],
+                                                                             decryptedRecordType: DR.Type = DR.self) -> Async<[DR]> {
         return async {
             let tagGroup = try await(taggingService.makeTagGroup(for: DR.Resource.self, annotations: annotations))
             if try tagGroup.hasPercentEncodableCharacters() {
@@ -171,11 +191,10 @@ struct RecordService: RecordServiceType {
                                                usingPercentEncodedTags: true,
                                                decryptedRecordType: decryptedRecordType))
             }
-
         }
     }
 
-    func countRecords<R: SDKResource>(userId: String, resourceType: R.Type, annotations: [String] = []) -> Async<Int> {
+    private func countRecordsIncludingLegacyTaggedOnes<R: SDKResource>(userId: String, resourceType: R.Type, annotations: [String] = []) -> Async<Int> {
         return async {
             let tagGroup = try await(taggingService.makeTagGroup(for: resourceType, annotations: annotations))
             if try tagGroup.hasPercentEncodableCharacters() {
@@ -189,66 +208,16 @@ struct RecordService: RecordServiceType {
     }
 }
 
-private extension RecordService {
-
-    func searchRecords<DR: DecryptedRecord>(for userId: String,
-                                            from startDate: Date?,
-                                            to endDate: Date?,
-                                            pageSize: Int?,
-                                            offset: Int?,
-                                            annotations: [String] = [],
-                                            usingPercentEncodedTags: Bool,
-                                            decryptedRecordType: DR.Type = DR.self) -> Async<[DR]> {
-        return async {
-            let tagGroup = try await(self.taggingService.makeTagGroup(for: DR.Resource.self, annotations: annotations))
-            let params = try await(self.buildParameters(from: startDate,
-                                                        to: endDate,
-                                                        offset: offset,
-                                                        pageSize: pageSize,
-                                                        tagGroup: tagGroup,
-                                                        usingPercentEncodedTags: usingPercentEncodedTags))
-
-            let route = Router.searchRecords(userId: userId, parameters: params)
-            let encryptedRecords: [EncryptedRecord] = try await(
-                self.sessionService.request(route: route).responseDecodable()
-            )
-
-            guard encryptedRecords.isEmpty == false else {
-                return []
-            }
-            return try encryptedRecords.map {
-                try await(DR.from(encryptedRecord: $0,
-                                  cryptoService: self.cryptoService,
-                                  commonKeyService: self.commonKeyService))
-            }
-        }
-    }
-
-    func countRecords<R: SDKResource>(userId: String, resourceType: R.Type, annotations: [String], usingPercentEncoding: Bool) -> Async<Int> {
-        return async {
-            let tagGroup = try await(self.taggingService.makeTagGroup(for: resourceType, annotations: annotations))
-            let params = try await(self.buildParameters(tagGroup: tagGroup, usingPercentEncodedTags: usingPercentEncoding))
-            let route = Router.countRecords(userId: userId, parameters: params)
-            let headers = try await(self.sessionService.request(route: route).responseHeaders())
-
-            guard
-                let countString = headers["x-total-count"] as? String,
-                let count = Int(countString) else {
-                throw Data4LifeSDKError.keyMissingInSerialization(key: "`x-total-count`")
-            }
-
-            return count
-        }
-    }
-
-    func uploadRecord<DR: DecryptedRecord>(forResource resource: DR.Resource,
-                                           userId: String,
-                                           dataKey: Key,
-                                           attachmentKey: Key? = nil,
-                                           oldTags: [String: String]? = nil,
-                                           annotations: [String]? = nil,
-                                           decryptedRecordType: DR.Type = DR.self,
-                                           uploadRequest: @escaping (Parameters) -> Router) -> Async<DR> {
+// MARK: - Common Record Service methods
+extension RecordService {
+    private func uploadRecord<DR: DecryptedRecord>(forResource resource: DR.Resource,
+                                                   userId: String,
+                                                   dataKey: Key,
+                                                   attachmentKey: Key? = nil,
+                                                   oldTags: [String: String]? = nil,
+                                                   annotations: [String]? = nil,
+                                                   decryptedRecordType: DR.Type = DR.self,
+                                                   uploadRequest: @escaping (Parameters) -> Router) -> Async<DR> {
         return async {
 
             let tagGroup = try await(self.taggingService.makeTagGroup(for: resource, oldTags: oldTags ?? [:], annotations: annotations))
@@ -304,12 +273,62 @@ private extension RecordService {
         }
     }
 
-    func buildParameters(from startDate: Date? = nil,
-                         to endDate: Date? = nil,
-                         offset: Int? = nil,
-                         pageSize: Int? = nil,
-                         tagGroup: TagGroup,
-                         usingPercentEncodedTags: Bool) throws -> Async<Parameters> {
+    private func searchRecords<DR: DecryptedRecord>(for userId: String,
+                                                    from startDate: Date?,
+                                                    to endDate: Date?,
+                                                    pageSize: Int?,
+                                                    offset: Int?,
+                                                    annotations: [String] = [],
+                                                    usingPercentEncodedTags: Bool,
+                                                    decryptedRecordType: DR.Type = DR.self) -> Async<[DR]> {
+        return async {
+            let tagGroup = try await(self.taggingService.makeTagGroup(for: DR.Resource.self, annotations: annotations))
+            let params = try await(self.buildParameters(from: startDate,
+                                                        to: endDate,
+                                                        offset: offset,
+                                                        pageSize: pageSize,
+                                                        tagGroup: tagGroup,
+                                                        usingPercentEncodedTags: usingPercentEncodedTags))
+
+            let route = Router.searchRecords(userId: userId, parameters: params)
+            let encryptedRecords: [EncryptedRecord] = try await(
+                self.sessionService.request(route: route).responseDecodable()
+            )
+
+            guard encryptedRecords.isEmpty == false else {
+                return []
+            }
+            return try encryptedRecords.map {
+                try await(DR.from(encryptedRecord: $0,
+                                  cryptoService: self.cryptoService,
+                                  commonKeyService: self.commonKeyService))
+            }
+        }
+    }
+
+    private func countRecords<R: SDKResource>(userId: String, resourceType: R.Type, annotations: [String], usingPercentEncoding: Bool) -> Async<Int> {
+        return async {
+            let tagGroup = try await(self.taggingService.makeTagGroup(for: resourceType, annotations: annotations))
+            let params = try await(self.buildParameters(tagGroup: tagGroup, usingPercentEncodedTags: usingPercentEncoding))
+            let route = Router.countRecords(userId: userId, parameters: params)
+            let headers = try await(self.sessionService.request(route: route).responseHeaders())
+
+            guard
+                let countString = headers["x-total-count"] as? String,
+                let count = Int(countString) else {
+                throw Data4LifeSDKError.keyMissingInSerialization(key: "`x-total-count`")
+            }
+
+            return count
+        }
+    }
+
+    private func buildParameters(from startDate: Date? = nil,
+                                 to endDate: Date? = nil,
+                                 offset: Int? = nil,
+                                 pageSize: Int? = nil,
+                                 tagGroup: TagGroup,
+                                 usingPercentEncodedTags: Bool) throws -> Async<Parameters> {
         return async {
             var parameters: Parameters = [:]
             guard let tek = self.cryptoService.tek else {

--- a/SDK/Tests/Factories/DecryptedRecordFactory.swift
+++ b/SDK/Tests/Factories/DecryptedRecordFactory.swift
@@ -19,6 +19,7 @@ import Data4LifeCrypto
 
 struct DecryptedRecordFactory {
     static func create<R: FhirR4Resource>(_ fhirResource: R,
+                                          annotations: [String] = [],
                                           dataKey: Key = KeyFactory.createKey(),
                                           attachmentKey: Key? = KeyFactory.createKey()) -> DecryptedFhirR4Record<R> {
         let tags = ["resourcetype": Swift.type(of: fhirResource).resourceType.rawValue.lowercased()]
@@ -28,13 +29,14 @@ struct DecryptedRecordFactory {
         return DecryptedFhirR4Record(id: id.value!.string,
                                      metadata: metadata,
                                      tags: tags,
-                                     annotations: [],
+                                     annotations: annotations,
                                      resource: fhirResource,
                                      dataKey: dataKey,
                                      attachmentKey: attachmentKey,
                                      modelVersion: R.modelVersion)
     }
     static func create<R: FhirStu3Resource>(_ fhirResource: R,
+                                            annotations: [String] = [],
                                             dataKey: Key = KeyFactory.createKey(),
                                             attachmentKey: Key? = KeyFactory.createKey()) -> DecryptedFhirStu3Record<R> {
         let tags = ["resourcetype": Swift.type(of: fhirResource).resourceType.lowercased()]
@@ -44,7 +46,7 @@ struct DecryptedRecordFactory {
         return DecryptedFhirStu3Record(id: id,
                                        metadata: metadata,
                                        tags: tags,
-                                       annotations: [],
+                                       annotations: annotations,
                                        resource: fhirResource.copy() as! R, // swiftlint:disable:this force_cast
             dataKey: dataKey,
             attachmentKey: attachmentKey,
@@ -52,6 +54,7 @@ struct DecryptedRecordFactory {
     }
 
     static func create(_ appData: Data,
+                       annotations: [String] = [],
                        dataKey: Key = KeyFactory.createKey()) -> DecryptedAppDataRecord {
         let tags = ["flag":"appdata"]
         let metadata = Metadata(updatedDate: Date(), createdDate: Date())
@@ -59,7 +62,7 @@ struct DecryptedRecordFactory {
                                       metadata: metadata,
                                       resource: appData,
                                       tags: tags,
-                                      annotations: [],
+                                      annotations: annotations,
                                       dataKey: dataKey,
                                       modelVersion: Data.modelVersion)
     }

--- a/SDK/Tests/ServiceTests/RecordService/RecordServiceTests+FhirStu3.swift
+++ b/SDK/Tests/ServiceTests/RecordService/RecordServiceTests+FhirStu3.swift
@@ -408,18 +408,69 @@ final class RecordServiceTests: XCTestCase { // swiftlint:disable:this type_body
         waitForExpectations(timeout: 5)
     }
 
-    func testSearchFhirStu3Records() {
+    func testSearchFhirStu3RecordsWithNonPercentEncodableTags() {
+        let annotations = ["exampleannotation1"]
+        let userId = UUID().uuidString
+        let startDate = Date()
+        let endDate = Date()
+        let document = FhirFactory.createStu3DocumentReferenceResource()
+        let record = DecryptedRecordFactory.create(document, annotations: annotations)
+        var encryptedRecord = EncryptedRecordFactory.create(for: record, resource: document, commonKeyId: commonKeyId)
+        encryptedRecord.encryptedAttachmentKey = nil
+
+        taggingService.tagTypeResult = Async.resolve(TagGroup(tags: ["resourcetype": "documentreference"], annotations: annotations))
+        taggingService.tagResourceResult = Async.resolve(TagGroup(tags: record.tags, annotations: record.annotations))
+        cryptoService.encryptValuesResult = encryptedRecord.encryptedTags
+        cryptoService.decryptValuesResult = encryptedRecord.encryptedTags
+
+        // Common key
+        commonKeyService.fetchKeyResult = Promise.resolve(commonKey)
+
+        // encrypted body
+        cryptoService.encryptValueResult = Async.resolve(encryptedRecord.encryptedBodyData)
+
+        // encrypted data key
+        cryptoService.encryptDataResult = encryptedRecord.encryptedDataKeyData
+        cryptoService.generateGCKeyResult = record.dataKey
+
+        // decrypt values for data key and body
+        let dataInput: (Data, Data) = (encryptedRecord.encryptedDataKeyData, encryptedRecord.encryptedDataKeyData)
+        let bodyInput: (Data, Data) = (encryptedRecord.encryptedBodyData, encryptedRecord.encryptedBodyData)
+        cryptoService.decryptDataForInput = [dataInput, bodyInput]
+
+        stub("GET", "/users/\(userId)/records", with: [encryptedRecord.json])
+
+        let asyncExpectation = expectation(description: "should return a list of records")
+        recordService.searchRecords(for: userId,
+                                    from: startDate,
+                                    to: endDate,
+                                    pageSize: 10,
+                                    offset: 0,
+                                    annotations: annotations,
+                                    decryptedRecordType: DecryptedFhirStu3Record<DocumentReference>.self)
+            .then { records in
+                defer { asyncExpectation.fulfill() }
+                XCTAssertEqual(records.count, 1)
+                XCTAssertEqual(record.resource, document)
+
+                XCTAssertEqual(self.taggingService.tagTypeCalledWith?.1, annotations)
+                XCTAssertEqual(record.annotations, annotations)
+            }
+
+        waitForExpectations(timeout: 5)
+    }
+
+    func testSearchFhirStu3RecordsWithPercentEncodableTags() {
         let annotations = ["example-annotation1"]
         let userId = UUID().uuidString
         let startDate = Date()
         let endDate = Date()
         let document = FhirFactory.createStu3DocumentReferenceResource()
-        var record = DecryptedRecordFactory.create(document)
-        record.annotations = annotations
+        let record = DecryptedRecordFactory.create(document, annotations: annotations)
         var encryptedRecord = EncryptedRecordFactory.create(for: record, resource: document, commonKeyId: commonKeyId)
         encryptedRecord.encryptedAttachmentKey = nil
 
-        taggingService.tagTypeResult = Async.resolve(TagGroup(tags: ["resourcetype": "documentreference"]))
+        taggingService.tagTypeResult = Async.resolve(TagGroup(tags: ["resourcetype": "documentreference"], annotations: annotations))
         taggingService.tagResourceResult = Async.resolve(TagGroup(tags: record.tags, annotations: record.annotations))
         cryptoService.encryptValuesResult = encryptedRecord.encryptedTags
         cryptoService.decryptValuesResult = encryptedRecord.encryptedTags
@@ -486,14 +537,36 @@ final class RecordServiceTests: XCTestCase { // swiftlint:disable:this type_body
         waitForExpectations(timeout: 5)
     }
 
-    func testCountFhirStu3Records() {
+    func testCountFhirStu3RecordsWithNonPercentEncodableTags() {
+        let annotations = ["exampleannotation1"]
+        let userId = UUID().uuidString
+        let recordCount = 101
+
+        stub("HEAD", "/users/\(userId)/records", with: Data(), headers: ["x-total-count" : "\(recordCount)"], code: 200)
+
+        taggingService.tagTypeResult = Async.resolve(TagGroup(tags: [:], annotations: annotations))
+        cryptoService.encryptValuesResult = []
+        cryptoService.decryptValuesResult = []
+
+        let asyncExpectation = expectation(description: "should return header containg record count")
+        recordService.countRecords(userId: userId, resourceType: DocumentReference.self, annotations: annotations)
+            .then { count in
+                defer { asyncExpectation.fulfill() }
+                XCTAssertEqual(count, recordCount)
+                XCTAssertEqual(self.taggingService.tagTypeCalledWith?.1, annotations)
+            }
+
+        waitForExpectations(timeout: 5)
+    }
+
+    func testCountFhirStu3RecordsWithPercentEncodableTags() {
         let annotations = ["example-annotation1"]
         let userId = UUID().uuidString
         let recordCount = 101
 
         stub("HEAD", "/users/\(userId)/records", with: Data(), headers: ["x-total-count" : "\(recordCount)"], code: 200)
 
-        taggingService.tagTypeResult = Async.resolve(TagGroup(tags: [:]))
+        taggingService.tagTypeResult = Async.resolve(TagGroup(tags: [:], annotations: annotations))
         cryptoService.encryptValuesResult = []
         cryptoService.decryptValuesResult = []
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds percent encodable check before deciding if doing double call or one

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With the current implementation, search and count would always be called twice even if the parameters didnt include percent-encodable tags, resulting in doubling the result.
This fix makes a check before to decide if doubling the call is right.

## How is it being implemented?
<!--- Please describe in detail how you implemented your changes. -->
<!--- Include details of your implemented environment, and the tests you ran to -->
Adds check if tags are the same as percent encoded and not

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Adds new tests, basic tested on example app.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the changelog accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
