### PR TITLE
[SDK-610] Readds middle step of the unarchiving migration

### DIFF
--- a/SDK/Sources/Services/OAuthService/OAuthService.swift
+++ b/SDK/Sources/Services/OAuthService/OAuthService.swift
@@ -87,6 +87,11 @@ class OAuthService: OAuthServiceType {
         self.keychainService = keychainService
         self.sessionService = sessionService
         self.numberOfRetriesOnTimeout = numberOfRetriesOnTimeout
+        migrateUnarchiverToD4L()
+    }
+
+    private func migrateUnarchiverToD4L() {
+        NSKeyedUnarchiver.setClass(Data4LifeSDK.AuthState.self, forClassName: "HCSDK.AuthState")
     }
 
     func retry(_ request: Request, for session: Session, dueTo error: Error, completion: @escaping (RetryResult) -> Void) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Old auth state was archived as `HCSDK.AuthState` still so removing the unarchiving migration meant that the auth data wasnt able to be unarchived as `Data4LifeSDK.AuthState`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Updating any app with latest version of SDK would log out automatically the user. This version fixes the bug. Migration was historically needed before the renaming of the SDK module from HCSDK to Data4LifeSDK, but it needed a half step to be removed. 

## How is it being implemented?
<!--- Please describe in detail how you implemented your changes. -->
<!--- Include details of your implemented environment, and the tests you ran to -->
Adds the unarchiving migration from old class name to latest class name

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Basic tested migration update. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the changelog accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
