### PR TITLE
Fix session service interceptor retry logic

### DIFF
--- a/HCSDK.xcodeproj/project.pbxproj
+++ b/HCSDK.xcodeproj/project.pbxproj
@@ -1557,7 +1557,6 @@
 				CD841DDC225CBE80002656D5 /* Extensions */,
 				CD841DF8225CBE80002656D5 /* Factories */,
 				CD841DD2225CBE80002656D5 /* Helpers */,
-				CD841DD5225CBE80002656D5 /* HelperTests */,
 				CD841DFE225CBE80002656D5 /* Info.plist */,
 				CD841DB3225CBE80002656D5 /* Mocks */,
 				CD841DF0225CBE80002656D5 /* ModelTests */,
@@ -1650,13 +1649,6 @@
 				CD841DD4225CBE80002656D5 /* StubbedURLProtocol.swift */,
 			);
 			path = Helpers;
-			sourceTree = "<group>";
-		};
-		CD841DD5225CBE80002656D5 /* HelperTests */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = HelperTests;
 			sourceTree = "<group>";
 		};
 		CD841DDA225CBE80002656D5 /* Certificates */ = {

--- a/SDK/Sources/DI/Containers/Data4LifeDIContainer.swift
+++ b/SDK/Sources/DI/Containers/Data4LifeDIContainer.swift
@@ -35,7 +35,7 @@ extension Data4LifeDIContainer {
             }.register(scope: .containerInstance) { (container) -> KeychainServiceType in
                 let keychainName = try clientConfiguration.keychainName()
                 return KeychainService(container: container, name: keychainName, groupId: clientConfiguration.keychainGroupId)
-            }.register(scope: .containerInstance) { (container) -> RequestInterceptorType in
+            }.register(scope: .globalInstance) { (container) -> RequestInterceptorType in
                 let infoService: InfoServiceType = try container.resolve()
                 let sdkVersion = infoService.fetchSDKVersion()
                 return SessionServiceInterceptor(keychainService: try container.resolve(),

--- a/SDK/Sources/Networking/SessionServiceInterceptor.swift
+++ b/SDK/Sources/Networking/SessionServiceInterceptor.swift
@@ -59,6 +59,10 @@ final class SessionServiceInterceptor: RequestInterceptorType {
                       for session: Session,
                       dueTo error: Error,
                       completion: @escaping (RetryResult) -> Void) {
-        retrier?.retry(request, for: session, dueTo: error, completion: completion)
+        if let retrier = retrier {
+            retrier.retry(request, for: session, dueTo: error, completion: completion)
+        } else {
+            completion(.doNotRetry)
+        }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Patches data race created on initialization and use of SessionServiceInterceptor

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When restarting the app somehow on init the SessionServiceInterceptor gets created twice and setting only the retrier on the first one, making the SDK not able to retry and blocking itself when access token is not refreshed. 
This PR does not fix that, but patches a work around in case data race happens. 

## How is it being implemented?
<!--- Please describe in detail how you implemented your changes. -->
<!--- Include details of your implemented environment, and the tests you ran to -->
Changes sessionInterceptor to be a global instance and adding a completion block when retrier is not yet set because of the data race.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Following the steps of [SDK-617](https://gesundheitscloud.atlassian.net/browse/SDK-617)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the changelog accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
